### PR TITLE
update readme for ca-certs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,10 @@ Alternatively, use `easy_install`::
 
     $ easy_install nubo
 
+You need to have `ca-certificates`_ installed on your system.
+
+.. _ca-certificates: https://wiki.apache.org/incubator/LibcloudSSL#Enabling_SSL_Certificate_Check
+
 Usage
 -----
 


### PR DESCRIPTION
Users need to make sure cert bundle file is in one of the places libcloud looks for the bundle. `nubo config` bombs out with a stack trace if this isn't done.
